### PR TITLE
Hide unused tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 - Hot corners
 - Kill mode (select a window to close it)
 - Cycling through layouts on click
+- Hide unused tags (and show them on bar hover)

--- a/dwm.c
+++ b/dwm.c
@@ -756,14 +756,18 @@ drawbar(Monitor *m)
 	}
 	x = 0;
 	for (i = 0; i < LENGTH(tags); i++) {
-		w = TEXTW(tags[i]);
-		drw_setscheme(drw, scheme[m->tagset[m->seltags] & 1 << i ? SchemeSel : SchemeNorm]);
-		drw_text(drw, x, 0, w, bh, lrpad / 2, tags[i], urg & 1 << i);
-		if (occ & 1 << i)
-			drw_rect(drw, x + boxs, boxs, boxw, boxw,
-				m == selmon && selmon->sel && selmon->sel->tags & 1 << i,
-				urg & 1 << i);
-		x += w;
+		if (occ & 1 << i || m->tagset[m->seltags] & 1 << i) {
+			w = TEXTW(tags[i]);
+			drw_setscheme(drw, scheme[m->tagset[m->seltags] & 1 << i ? 
+					SchemeSel : SchemeNorm]);
+			drw_text(drw, x, 0, w, bh, lrpad / 2, tags[i], urg & 1 << i);
+			if (occ & 1 << i)
+				drw_rect(drw, x + boxs, boxs, boxw, boxw,
+						m == selmon && selmon->sel
+						&& selmon->sel->tags & 1 << i,
+						urg & 1 << i);
+			x += w;
+		}
 	}
 	w = blw = TEXTW(m->ltsymbol);
 	drw_setscheme(drw, scheme[SchemeNorm]);


### PR DESCRIPTION
Hide unused tags and show them on bar hover.
Sidenote: The second commit, 961569bc3d1646c93adcad4248c1cc211c184771 is rendered completely useless by the third (because showing all tags, well, shows all tags...) but I kept it just in case the hover feature is to be disabled.